### PR TITLE
dependency: bump version of btcspv, refactor for new API

### DIFF
--- a/golang/go.mod
+++ b/golang/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.5.0
 	github.com/stretchr/testify v1.4.0
-	github.com/summa-tx/bitcoin-spv/golang v1.2.0
+	github.com/summa-tx/bitcoin-spv/golang v1.3.0
 	github.com/tendermint/go-amino v0.15.0
 	github.com/tendermint/tendermint v0.32.2
 	github.com/tendermint/tm-db v0.1.1

--- a/golang/go.sum
+++ b/golang/go.sum
@@ -367,6 +367,8 @@ github.com/summa-tx/bitcoin-spv/golang v1.1.1-0.20191113003027-995ff9fb2d07 h1:5
 github.com/summa-tx/bitcoin-spv/golang v1.1.1-0.20191113003027-995ff9fb2d07/go.mod h1:8VS5yAT8po0RU1YM86UIr1klFm0/JBf5bZHL0eHpYLs=
 github.com/summa-tx/bitcoin-spv/golang v1.2.0 h1:d9VSHSb4HMQOYshbOTRh26g5yU4tUiBIn4cr9hlB2CE=
 github.com/summa-tx/bitcoin-spv/golang v1.2.0/go.mod h1:8VS5yAT8po0RU1YM86UIr1klFm0/JBf5bZHL0eHpYLs=
+github.com/summa-tx/bitcoin-spv/golang v1.3.0 h1:BHs+LZsCYd/UhHssiGuj6TZ3h8eBytIOVtiBTfVOiLc=
+github.com/summa-tx/bitcoin-spv/golang v1.3.0/go.mod h1:8VS5yAT8po0RU1YM86UIr1klFm0/JBf5bZHL0eHpYLs=
 github.com/syndtr/goleveldb v0.0.0-20180708030551-c4c61651e9e3 h1:sAlSBRDl4psFR3ysKXRSE8ss6Mt90+ma1zRTroTNBJA=
 github.com/syndtr/goleveldb v0.0.0-20180708030551-c4c61651e9e3/go.mod h1:Z4AUp2Km+PwemOoO/VB5AOx9XSsIItzFjoJlOSiYmn0=
 github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965 h1:1oFLiOyVl+W7bnBzGhf7BbIv9loSFQcieWWYIjLqcAw=

--- a/golang/x/relay/client/cli/tx.go
+++ b/golang/x/relay/client/cli/tx.go
@@ -197,7 +197,6 @@ func GetCmdMarkNewHeaviest(cdc *codec.Codec) *cobra.Command {
 			}
 
 			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
-
 		},
 	}
 }

--- a/golang/x/relay/keeper/keeper_test.go
+++ b/golang/x/relay/keeper/keeper_test.go
@@ -164,8 +164,8 @@ type ValidatorTestCases struct {
 
 /***** Request TEST CASES *****/
 type CheckRequestTestCase struct {
-	InputIdx  uint8           `json:"inputIndex"`
-	OutputIdx uint8           `json:"outputIndex"`
+	InputIdx  uint32           `json:"inputIndex"`
+	OutputIdx uint32           `json:"outputIndex"`
 	Vin       types.HexBytes  `json:"vin"`
 	Vout      types.HexBytes  `json:"vout"`
 	RequestID types.RequestID `json:"requestID"`

--- a/golang/x/relay/keeper/request_test.go
+++ b/golang/x/relay/keeper/request_test.go
@@ -131,7 +131,7 @@ func (s *KeeperSuite) TestCheckRequests() {
 	s.Equal(sdk.CodeType(607), err.Code())
 
 	// Errors if output value is less than pays value
-	out, outErr := btcspv.ExtractOutputAtIndex(v.Vout, v.OutputIdx)
+	out, outErr := btcspv.ExtractOutputAtIndex(v.Vout, uint(v.OutputIdx))
 	s.Nil(outErr)
 	// out[8:] extracts the output script which we use to set the request
 	requestErr = s.Keeper.setRequest(s.Context, []byte{0}, out[8:], 1000, 0)
@@ -158,7 +158,8 @@ func (s *KeeperSuite) TestCheckRequests() {
 	s.Equal(sdk.CodeType(609), err.Code())
 
 	// Success
-	in := btcspv.ExtractInputAtIndex(v.Vin, v.InputIdx)
+	in, extractErr := btcspv.ExtractInputAtIndex(v.Vin, uint(v.InputIdx))
+	s.Nil(extractErr)
 	outpoint := btcspv.ExtractOutpoint(in)
 	// out[8:] extracts the output script which we use to set the request
 	requestErr = s.Keeper.setRequest(s.Context, outpoint, out[8:], 10, 255)

--- a/golang/x/relay/types/validator.go
+++ b/golang/x/relay/types/validator.go
@@ -1,9 +1,9 @@
 package types
 
 type FilledRequestInfo struct {
-	InputIndex  uint8     `json:"inputIndex"`
-	OutputIndex uint8     `json:"outputIndex"`
-	ID          RequestID `json:"id"`
+	InputIndex  uint32     `json:"inputIndex"`
+	OutputIndex uint32     `json:"outputIndex"`
+	ID          RequestID  `json:"id"`
 }
 
 type FilledRequests struct {


### PR DESCRIPTION
bitcon-spv API changed slightly in latest version. This PR updates to account for that, and to allow Vin/Vout sizes > 253 in request validation 