### PR TITLE
Bug fixes for marking new heaviest digest

### DIFF
--- a/golang/x/relay/client/cli/query.go
+++ b/golang/x/relay/client/cli/query.go
@@ -215,7 +215,7 @@ func GetCmdIsMostRecentCommonAncestor(queryRoute string, cdc *codec.Codec) *cobr
 				return nil
 			}
 
-			right, sdkErr := types.Hash256DigestFromHex(args[1])
+			right, sdkErr := types.Hash256DigestFromHex(args[2])
 			if sdkErr != nil {
 				fmt.Print(sdkErr.Error())
 				return nil

--- a/golang/x/relay/client/cli/utils.go
+++ b/golang/x/relay/client/cli/utils.go
@@ -1,14 +1,14 @@
 package cli
 
 import (
-    "io/ioutil"
-    "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
+	"io/ioutil"
 )
 
 func readJSONFromFile(filename string) ([]byte, error) {
-    return ioutil.ReadFile("scripts/json_data/" + filename)
+	return ioutil.ReadFile("scripts/json_data/" + filename)
 }
 
 func attachFlagFileinput(cmd *cobra.Command) {
-    cmd.Flags().Bool("inputfile", false, "Accepts a file as input for each json parameter")
+	cmd.Flags().Bool("inputfile", false, "Accepts a file as input for each json parameter")
 }

--- a/golang/x/relay/genesis.go
+++ b/golang/x/relay/genesis.go
@@ -58,7 +58,7 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data GenesisState) []abci.Valid
 	if err != nil {
 		panic("already init!")
 	}
-	if (len(data.Headers) > 1) {
+	if len(data.Headers) > 1 {
 		err = keeper.IngestHeaderChain(ctx, data.Headers[1:])
 		if err != nil {
 			panic("Bad header chain in genesis state! " + err.Error())

--- a/golang/x/relay/keeper/chain.go
+++ b/golang/x/relay/keeper/chain.go
@@ -118,7 +118,6 @@ func (k Keeper) HeaviestFromAncestor(ctx sdk.Context, ancestor, currentBest, new
 		3. Both are in the same window, choose the higher one
 		4. They're in different new windows. Choose the heavier one
 	*/
-
 	if !leftInPeriod && rightInPeriod {
 		return leftBlock.HashLE, nil
 	}

--- a/golang/x/relay/keeper/keeper_test.go
+++ b/golang/x/relay/keeper/keeper_test.go
@@ -263,20 +263,20 @@ func TestKeeper(t *testing.T) {
 	suite.Run(t, keeperSuite)
 }
 
-func (suite *KeeperSuite) SDKNil(e sdk.Error) {
+func (s *KeeperSuite) SDKNil(e sdk.Error) {
 	var msg string
 	if e != nil {
 		msg = e.Error()
 	}
-	suite.Nil(e, msg)
+	s.Nil(e, msg)
 }
 
-func (suite *KeeperSuite) EqualError(e sdk.Error, code int) {
+func (s *KeeperSuite) EqualError(e sdk.Error, code int) {
 	var msg string
 	if e.Code() != sdk.CodeType(code) {
 		msg = fmt.Sprintf("%sExpected: %d\n", e.Error(), code)
 	}
-	suite.Equal(sdk.CodeType(code), e.Code(), msg)
+	s.Equal(sdk.CodeType(code), e.Code(), msg)
 }
 
 func (s *KeeperSuite) TestGetPrefixStore() {

--- a/golang/x/relay/keeper/querier_test.go
+++ b/golang/x/relay/keeper/querier_test.go
@@ -8,7 +8,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 )
 
-func (suite *KeeperSuite) TestDecodeUint32FromPath() {
+func (s *KeeperSuite) TestDecodeUint32FromPath() {
 	DecodeUintPass := []struct {
 		Path         []string
 		Idx          int
@@ -47,15 +47,15 @@ func (suite *KeeperSuite) TestDecodeUint32FromPath() {
 		index := DecodeUintPass[i].Idx
 		limit := DecodeUintPass[i].DefaultLimit
 		num, err := decodeUint32FromPath(path, index, limit)
-		suite.SDKNil(err)
-		suite.Equal(num, DecodeUintPass[i].Output)
+		s.SDKNil(err)
+		s.Equal(num, DecodeUintPass[i].Output)
 	}
 	for i := range DecodeUintFail {
 		path := DecodeUintFail[i].Path
 		index := DecodeUintFail[i].Idx
 		limit := DecodeUintFail[i].DefaultLimit
 		_, err := decodeUint32FromPath(path, index, limit)
-		suite.Equal(DecodeUintFail[i].Err, err.Code())
+		s.Equal(DecodeUintFail[i].Err, err.Code())
 	}
 }
 

--- a/golang/x/relay/keeper/requests.go
+++ b/golang/x/relay/keeper/requests.go
@@ -41,7 +41,6 @@ func (k Keeper) setRequest(ctx sdk.Context, spends []byte, pays []byte, paysValu
 		paysDigest = btcspv.Hash256(pays)
 	}
 
-
 	request := types.ProofRequest{
 		Spends:      spendsDigest,
 		Pays:        paysDigest,

--- a/golang/x/relay/types/msgs.go
+++ b/golang/x/relay/types/msgs.go
@@ -108,6 +108,10 @@ type MsgMarkNewHeaviest struct {
 
 // NewMsgMarkNewHeaviest instantiates a MsgMarkNewHeaviest
 func NewMsgMarkNewHeaviest(address sdk.AccAddress, ancestor Hash256Digest, currentBest RawHeader, newBest RawHeader, limit uint32) MsgMarkNewHeaviest {
+	if limit == 0 {
+		limit = DefaultLookupLimit
+	}
+
 	return MsgMarkNewHeaviest{
 		address,
 		ancestor,
@@ -179,7 +183,7 @@ func (msg MsgNewRequest) Type() string { return "new_request" }
 // ValidateBasic runs stateless validation
 func (msg MsgNewRequest) ValidateBasic() sdk.Error {
 	// TODO: validate output types
-	if len(msg.Spends) != 36  && len(msg.Spends) != 0 {
+	if len(msg.Spends) != 36 && len(msg.Spends) != 0 {
 		return ErrSpendsLength(DefaultCodespace)
 	}
 	if len(msg.Pays) > 50 {

--- a/golang/x/relay/types/querier.go
+++ b/golang/x/relay/types/querier.go
@@ -31,7 +31,7 @@ const (
 	// QueryGetRequest is a query string tag for getRequest
 	QueryGetRequest = "getrequest"
 
-	// QueryCheckRequest is a query string tag for checkRequests
+	// QueryCheckRequests is a query string tag for checkRequests
 	QueryCheckRequests = "checkrequests"
 
 	// QueryCheckProof is a query string tag for checkProof


### PR DESCRIPTION
bugs fixed
- CLI Query reusing one arg and ignoring one arg
- no default limit when making a `marknewheaviest` msg

buncha linting 