### PR TITLE
tests: fix tests I broke in a previous PR

### DIFF
--- a/golang/x/relay/keeper/request_test.go
+++ b/golang/x/relay/keeper/request_test.go
@@ -146,7 +146,7 @@ func (s *KeeperSuite) TestCheckRequests() {
 	s.Equal(sdk.CodeType(608), err.Code())
 
 	// Errors if input value does not equal spends value
-	requestErr = s.Keeper.setRequest(s.Context, []byte{1}, []byte{0}, 0, 255, types.Local, nil)
+	requestErr = s.Keeper.setRequest(s.Context, []byte{1}, []byte{}, 0, 255, types.Local, nil)
 	s.SDKNil(requestErr)
 	err = s.Keeper.checkRequests(
 		s.Context,

--- a/golang/x/relay/keeper/requests.go
+++ b/golang/x/relay/keeper/requests.go
@@ -35,7 +35,7 @@ func (k Keeper) setRequest(ctx sdk.Context, spends []byte, pays []byte, paysValu
 	}
 
 	var paysDigest types.Hash256Digest
-	if len(spends) == 0 {
+	if len(pays) == 0 {
 		paysDigest = types.Hash256Digest{}
 	} else {
 		paysDigest = btcspv.Hash256(pays)

--- a/golang/x/relay/keeper/validator_test.go
+++ b/golang/x/relay/keeper/validator_test.go
@@ -67,7 +67,7 @@ func (s *KeeperSuite) TestCheckRequestsFilled() {
 	s.Keeper.ingestHeader(s.Context, validProof.Proof.ConfirmingHeader)
 	s.Keeper.setLink(s.Context, validProof.Proof.ConfirmingHeader)
 	s.Keeper.ingestHeader(s.Context, validProof.BestKnown)
-	requestErr := s.Keeper.setRequest(s.Context, []byte{0}, []byte{0}, 0, 4, types.Local, nil)
+	requestErr := s.Keeper.setRequest(s.Context, []byte{}, []byte{}, 0, 4, types.Local, nil)
 	s.Nil(requestErr)
 
 	// errors if getConfs fails


### PR DESCRIPTION
I broke a few tests in my fix for #47. This updates them to use the new empty-byte-slice semantics. Also fixes a bug in setting `Pays` in stored requests