### PR TITLE
Proof handler interface

### DIFF
--- a/golang/EXTENDING.md
+++ b/golang/EXTENDING.md
@@ -7,14 +7,36 @@ other functionality should likely be put into a separate module.
 
 ### Integrating with other modules
 
-An instance of `relay.Keeper` should be added to your app in `app.go`. It can
-be instantiated as follows:
+The relay keeper keeps a reference to an object that implements the following
+interface (found in `x/types/types.go`).
 
+```go
+type ProofHandler interface {
+	HandleValidProof(ctx sdk.Context, filled FilledRequests, requests []ProofRequest)
+}
 ```
+
+The `FilledRequests` struct contains an `SPVProof` and supporting information
+about the transaction that fulfills the request.
+It can be found in `x/types/validator.go`. `requests []ProofRequest` is a slice
+of `ProofRequest`s that have been filled.
+
+When the keeper validates a proof, it will call the `HandleValidProof` function
+with the valid `FilledRequests` struct and the `ProofRequests` that have been
+filled.
+
+First, instantiate a `handler` that fulfills the `ProofHandler` interface. Then
+add an instance of `relay.Keeper` to your app in `app.go`. It can be
+instantiated as follows:
+
+```go
+handler = types.NewNullHandler()  // or your preferred handler
+
 app.relayKeeper = relay.NewKeeper(
   keys[relay.StoreKey],
   app.cdc,
-  true, // Mainnet // TODO: pass this in somehow
+  true,
+  handler
 )
 ```
 

--- a/golang/README.md
+++ b/golang/README.md
@@ -44,7 +44,7 @@ Instructions for setting up manual testing can be found in the README in
 - - [X] Integration Tests
 - - [ ] Document relay design & architecture
 - - [X] Document public interface
-- - [ ] Provide hooks to execute tasks + dispatch messages
+- - [X] Provide hooks to execute tasks + dispatch messages
 - - [ ] Add a basic web dashboard with Relay health
 
 

--- a/golang/fake_app.go
+++ b/golang/fake_app.go
@@ -195,7 +195,8 @@ func NewRelayApp(logger log.Logger, db dbm.DB, baseAppOptions ...func(*bam.BaseA
 	app.relayKeeper = relay.NewKeeper(
 		keys[relay.StoreKey],
 		app.cdc,
-		true, // Mainnet // TODO: pass this in somehow
+		true,                // Mainnet // TODO: pass this in somehow
+		relay.NullHandler{}, // Proof Handler. real apps should fill this in
 	)
 
 	app.mm = module.NewManager(

--- a/golang/x/relay/alias.go
+++ b/golang/x/relay/alias.go
@@ -58,4 +58,10 @@ type (
 
 	// SPVProof is the base struct for an SPV proof
 	SPVProof = types.SPVProof
+
+	// ProofHandler is an interface to which the keepers dispatches valid proofs
+	ProofHandler = types.ProofHandler
+
+	// NullHandler does nothing
+	NullHandler = types.NullHandler
 )

--- a/golang/x/relay/keeper/handler.go
+++ b/golang/x/relay/keeper/handler.go
@@ -83,7 +83,9 @@ func handleMsgProvideProof(ctx sdk.Context, keeper Keeper, msg types.MsgProvideP
 		return err.Result()
 	}
 
-	// TODO: Add "hooks"
+	// Dispatch the proof to the keeper's proof handler
+	keeper.ProofHandler.HandleValidProof(ctx, msg.Filled)
+
 	return sdk.Result{
 		Events: ctx.EventManager().Events(),
 	}

--- a/golang/x/relay/keeper/handler.go
+++ b/golang/x/relay/keeper/handler.go
@@ -78,13 +78,13 @@ func handleMsgNewRequest(ctx sdk.Context, keeper Keeper, msg types.MsgNewRequest
 }
 
 func handleMsgProvideProof(ctx sdk.Context, keeper Keeper, msg types.MsgProvideProof) sdk.Result {
-	err := keeper.checkRequestsFilled(ctx, msg.Filled)
+	filled, err := keeper.checkRequestsFilled(ctx, msg.Filled)
 	if err != nil {
 		return err.Result()
 	}
 
 	// Dispatch the proof to the keeper's proof handler
-	keeper.ProofHandler.HandleValidProof(ctx, msg.Filled)
+	keeper.ProofHandler.HandleValidProof(ctx, msg.Filled, filled)
 
 	return sdk.Result{
 		Events: ctx.EventManager().Events(),

--- a/golang/x/relay/keeper/keeper.go
+++ b/golang/x/relay/keeper/keeper.go
@@ -11,17 +11,19 @@ import (
 
 // Keeper maintains the link to data storage and exposes getter/setter methods for the various parts of the state machine
 type Keeper struct {
-	storeKey  sdk.StoreKey // Unexposed key to access store from sdk.Context
-	cdc       *codec.Codec // The wire codec for binary encoding/decoding.
-	IsMainNet bool
+	storeKey     sdk.StoreKey // Unexposed key to access store from sdk.Context
+	cdc          *codec.Codec // The wire codec for binary encoding/decoding.
+	IsMainNet    bool
+	ProofHandler types.ProofHandler
 }
 
 // NewKeeper instantiates a new keeper
-func NewKeeper(storeKey sdk.StoreKey, cdc *codec.Codec, mainnet bool) Keeper {
+func NewKeeper(storeKey sdk.StoreKey, cdc *codec.Codec, mainnet bool, handler types.ProofHandler) Keeper {
 	return Keeper{
-		storeKey:  storeKey,
-		cdc:       cdc,
-		IsMainNet: mainnet,
+		storeKey:     storeKey,
+		cdc:          cdc,
+		IsMainNet:    mainnet,
+		ProofHandler: handler,
 	}
 }
 

--- a/golang/x/relay/keeper/keeper_test.go
+++ b/golang/x/relay/keeper/keeper_test.go
@@ -234,7 +234,7 @@ func (s *KeeperSuite) InitTestContext(mainnet, isCheckTx bool) {
 	cdc := codec.New()
 
 	ctx := sdk.NewContext(ms, abci.Header{ChainID: "relayTestChain"}, isCheckTx, tmlog.NewNopLogger())
-	keeper := NewKeeper(relayKey, cdc, mainnet)
+	keeper := NewKeeper(relayKey, cdc, mainnet, types.NewNullHandler())
 
 	s.Context = ctx
 	s.Keeper = keeper

--- a/golang/x/relay/keeper/querier.go
+++ b/golang/x/relay/keeper/querier.go
@@ -272,7 +272,7 @@ func queryCheckRequests(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) (
 	}
 
 	// This calls the keeper with the parsed arguments, and gets an answer
-	resErr := keeper.checkRequestsFilled(ctx, params.Filled)
+	_, resErr := keeper.checkRequestsFilled(ctx, params.Filled)
 	if resErr != nil {
 		valid = false
 		errMsg = resErr.Error()

--- a/golang/x/relay/keeper/validator_test.go
+++ b/golang/x/relay/keeper/validator_test.go
@@ -71,7 +71,7 @@ func (s *KeeperSuite) TestCheckRequestsFilled() {
 	s.Nil(requestErr)
 
 	// errors if getConfs fails
-	err := s.Keeper.checkRequestsFilled(s.Context, tc[0].FilledRequests)
+	_, err := s.Keeper.checkRequestsFilled(s.Context, tc[0].FilledRequests)
 	s.Equal(sdk.CodeType(105), err.Code())
 
 	s.Keeper.setBestKnownDigest(s.Context, validProof.BestKnown.Hash)
@@ -81,7 +81,7 @@ func (s *KeeperSuite) TestCheckRequestsFilled() {
 	activeErr := s.Keeper.setRequestState(s.Context, types.RequestID{}, false)
 	s.SDKNil(activeErr)
 
-	err = s.Keeper.checkRequestsFilled(s.Context, tc[0].FilledRequests)
+	_, err = s.Keeper.checkRequestsFilled(s.Context, tc[0].FilledRequests)
 	s.Equal(sdk.CodeType(606), err.Code())
 
 	// reactivate request
@@ -89,7 +89,7 @@ func (s *KeeperSuite) TestCheckRequestsFilled() {
 	s.SDKNil(activeErr)
 
 	for i := range tc {
-		err := s.Keeper.checkRequestsFilled(s.Context, tc[i].FilledRequests)
+		_, err := s.Keeper.checkRequestsFilled(s.Context, tc[i].FilledRequests)
 		if tc[i].Error != 0 {
 			s.Equal(sdk.CodeType(tc[i].Error), err.Code())
 		} else {
@@ -103,6 +103,6 @@ func (s *KeeperSuite) TestCheckRequestsFilled() {
 
 	copiedRequest := tc[0].FilledRequests
 	copiedRequest.Filled[0].ID = types.RequestID{0, 0, 0, 0, 0, 0, 0, 1}
-	err = s.Keeper.checkRequestsFilled(s.Context, copiedRequest)
+	_, err = s.Keeper.checkRequestsFilled(s.Context, copiedRequest)
 	s.Equal(sdk.CodeType(611), err.Code())
 }

--- a/golang/x/relay/types/types.go
+++ b/golang/x/relay/types/types.go
@@ -10,7 +10,7 @@ import (
 
 // ProofHandler is an interface to which the keeper dispatches valid proofs
 type ProofHandler interface {
-	HandleValidProof(ctx sdk.Context, filled FilledRequests)
+	HandleValidProof(ctx sdk.Context, filled FilledRequests, requests []ProofRequest)
 }
 
 // Hash256Digest 32-byte double-sha2 digest
@@ -63,7 +63,8 @@ func Hash256DigestFromHex(hexStr string) (Hash256Digest, sdk.Error) {
 type NullHandler struct{}
 
 // HandleValidProof handles a valid proof (by doing nothing)
-func (n NullHandler) HandleValidProof(ctx sdk.Context, filled FilledRequests) {}
+func (n NullHandler) HandleValidProof(ctx sdk.Context, filled FilledRequests, requests []ProofRequest) {
+}
 
 // NewNullHandler instantiates a new null handler
 func NewNullHandler() NullHandler {

--- a/golang/x/relay/types/types.go
+++ b/golang/x/relay/types/types.go
@@ -8,6 +8,11 @@ import (
 	"github.com/summa-tx/bitcoin-spv/golang/btcspv"
 )
 
+// ProofHandler is an interface to which the keeper dispatches valid proofs
+type ProofHandler interface {
+	HandleValidProof(ctx sdk.Context, filled FilledRequests)
+}
+
 // Hash256Digest 32-byte double-sha2 digest
 type Hash256Digest = btcspv.Hash256Digest
 
@@ -52,4 +57,15 @@ func Hash256DigestFromHex(hexStr string) (Hash256Digest, sdk.Error) {
 		return Hash256Digest{}, FromBTCSPVError(DefaultCodespace, newDigestErr)
 	}
 	return digest, nil
+}
+
+// NullHandler does nothing
+type NullHandler struct{}
+
+// HandleValidProof handles a valid proof (by doing nothing)
+func (n NullHandler) HandleValidProof(ctx sdk.Context, filled FilledRequests) {}
+
+// NewNullHandler instantiates a new null handler
+func NewNullHandler() NullHandler {
+	return NullHandler{}
 }


### PR DESCRIPTION
Adds an interface by which the app can hook into valid proofs. This is set on keeper instantiation right now. Eventually, we should consider a handler registration system like in the ante module

includes #71 