### PR TITLE
Fix Click-To-Copy

### DIFF
--- a/golang/dashboard/src/components/Click-To-Copy.vue
+++ b/golang/dashboard/src/components/Click-To-Copy.vue
@@ -1,14 +1,14 @@
 <template>
-  <div class="ctc">
+  <div class="ctc" @mouseleave="resetCopyText">
     <v-tooltip
-      v-model="copied"
       nudge-top="8"
       bottom
       class="ctc__copy"
+      content-class="tooltip-text"
     >
-      <template>
-        <v-btn icon color="teal">
-          <v-icon @click="handleCopy" id="ctc__icon">
+      <template v-slot:activator="{ on }">
+        <v-btn v-on="on" icon color="teal">
+          <v-icon @click="handleCopy" size="16px">
             content_copy
           </v-icon>
         </v-btn>
@@ -27,37 +27,30 @@ export default {
       required: true,
       type: [String, Number, undefined],
       default: ''
-    },
-    copyText: {
-      type: String,
-      default: 'Copied'
     }
   },
 
   data: () => ({
-    copied: false
+    copyText: 'Copy'
   }),
 
   methods: {
     handleCopy () {
-      const self = this
-
       if (navigator.clipboard) {
-        navigator.clipboard.writeText(this.copyValue).then(function () {
-          self.copyText = 'Copied'
-          self.copied = true
+        navigator.clipboard.writeText(this.copyValue).then(() => {
+          this.copyText = 'Copied'
         }, function () {
-          self.copyText = 'Error: Not Copied'
-          self.copied = false
+          this.copyText = 'Error: Not Copied'
         })
       } else {
-        self.copyText = 'Error: Not Copied'
-        self.copied = false
+        this.copyText = 'Error: Not Copied'
       }
+    },
 
+    resetCopyText () {
       setTimeout(() => {
-        self.copied = false
-      }, 2000)
+        this.copyText = 'Copy'
+      }, 500)
     }
   }
 }
@@ -70,8 +63,9 @@ export default {
   margin-left: 10px;
 }
 
-/* TODO: BAD. only doing this for now to get it working. fix later. */
-#ctc__icon {
-  font-size: 16px;
+.tooltip-text {
+  font-size: 12px;
+  /* height: 16px; */
+  padding: 2px 10px;
 }
 </style>

--- a/golang/dashboard/src/components/Click-To-Copy.vue
+++ b/golang/dashboard/src/components/Click-To-Copy.vue
@@ -42,6 +42,11 @@ export default {
         }, function () {
           this.copyText = 'Error: Not Copied'
         })
+      } else if (document.execCommand && document.body.createTextRange) {
+        const range = document.body.createTextRange()
+        range.moveToElementText(this.copyText)
+        range.select()
+        document.execCommand('copy')
       } else {
         this.copyText = 'Error: Not Copied'
       }

--- a/golang/dashboard/src/components/Relay-Info.vue
+++ b/golang/dashboard/src/components/Relay-Info.vue
@@ -23,6 +23,7 @@
             <Click-To-Copy :copy-value="height"/>
           </v-flex>
           <v-flex class="relay__info__info" row>
+            <p><b>Hash:</b> {{ currentBlock.hash }}</p>
             <Click-To-Copy :copy-value="currentBlock.hash"/>
           </v-flex>
           <v-flex class="relay__info__info" row>


### PR DESCRIPTION
Closes #84 
 - Fixed Click-To-Copy component (we must have upgraded versions on Vuetify when we moved this over).
 - I must have accidentally deleted the "hash" field for current block when restructuring, added it back in.
 - Added support for all browsers in Click-To-Copy.  We must have copied this code from the auction app which only needed to support Chrome.
 - Added mouse-leave event, we should think about adding that to our click-to-copy component in the component library.