### PR TITLE
Move health check info

### DIFF
--- a/golang/dashboard/src/components/Click-To-Copy.vue
+++ b/golang/dashboard/src/components/Click-To-Copy.vue
@@ -70,7 +70,6 @@ export default {
 
 .tooltip-text {
   font-size: 12px;
-  /* height: 16px; */
   padding: 2px 10px;
 }
 </style>

--- a/golang/dashboard/src/components/Relay-Health-Check.vue
+++ b/golang/dashboard/src/components/Relay-Health-Check.vue
@@ -36,17 +36,14 @@ import { getMinsAgo } from '@/utils/utils'
 export default {
   name: 'RelayHealthCheck',
 
-  data: () => ({
-    verifiedAt: null,
-    lastCommsExternal: null,
-    lastCommsRelay: null
-  }),
-
   computed: {
     ...mapState({
       lastComms: state => state.info.lastComms,
       currentBlock: state => state.info.currentBlock,
-      source: state => state.info.source
+      source: state => state.info.source,
+      verifiedAt: state => state.info.minsAgo.currentBlockVerified,
+      lastCommsExternal: state => state.info.minsAgo.sourceHealthCheck,
+      lastCommsRelay: state => state.info.minsAgo.relayHealthCheck
     })
   },
 
@@ -72,9 +69,15 @@ export default {
 
   methods: {
     healthCheckMins () {
-      this.verifiedAt = this.currentBlock.verifiedAt ? getMinsAgo(this.currentBlock.verifiedAt) : null
-      this.lastCommsExternal = this.lastComms.external ? getMinsAgo(this.lastComms.external) : null
-      this.lastCommsRelay = this.lastComms.relay ? getMinsAgo(this.lastComms.relay) : null
+      const currentBlockVerified = this.currentBlock.verifiedAt ? getMinsAgo(this.currentBlock.verifiedAt) : null
+      const relayHealthCheck = this.lastComms.relay ? getMinsAgo(this.lastComms.relay) : null
+      const sourceHealthCheck = this.lastComms.external ? getMinsAgo(this.lastComms.external) : null
+
+      this.$store.dispatch('info/setMinsAgo', {
+        currentBlockVerified,
+        relayHealthCheck,
+        sourceHealthCheck
+      })
     }
   }
 }

--- a/golang/dashboard/src/components/Relay-Health-Check.vue
+++ b/golang/dashboard/src/components/Relay-Health-Check.vue
@@ -1,0 +1,105 @@
+<template>
+  <v-card class="relay-updates">
+    <v-layout>
+      <p class="relay-updates__title">Relay Health Check:</p>
+      <p v-if="lastCommsRelay === null">Not completed</p>
+      <p v-else-if="lastCommsRelay < 1">Less than 1 minute ago</p>
+      <p v-else>{{ lastCommsRelay }} minute<span v-if="lastCommsRelay > 1">s</span> ago</p>
+    </v-layout>
+    <v-layout>
+      <p class="relay-updates__title">Source:</p>
+      <p>{{ source }}</p>
+    </v-layout>
+    <v-layout>
+      <p class="relay-updates__title">Source Health Check:</p>
+      <p v-if="lastCommsExternal === null">Not completed</p>
+      <p v-else-if="lastCommsExternal < 1">Less than 1 minute ago</p>
+      <p v-else>{{ lastCommsExternal }} minute<span v-if="lastCommsExternal > 1">s</span> ago</p>
+    </v-layout>
+    <v-layout>
+      <p class="relay-updates__title">Source Block Changed:</p>
+      <p v-if="verifiedAt === null">Unknown</p>
+      <p v-else-if="verifiedAt < 1">Less than 1 minute ago</p>
+      <p v-else>{{ verifiedAt }} minute<span v-if="verifiedAt > 1">s</span> ago</p>
+    </v-layout>
+    <v-layout>
+      <p class="relay-updates__title">Source Height:</p>
+      <p>{{ currentBlock.height || 'Unknown' }}</p>
+    </v-layout>
+  </v-card>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import { getMinsAgo } from '@/utils/utils'
+
+export default {
+  name: 'RelayHealthCheck',
+
+  components: {
+    ClickToCopy: () => import(/* webpackChunkName: 'Click-To-Copy' */ './Click-To-Copy'),
+    NetType: () => import(/* webpackChunkName: 'Net-Type' */ './Net-Type')
+  },
+
+  data: () => ({
+    verifiedAt: null,
+    lastCommsExternal: null,
+    lastCommsRelay: null
+  }),
+
+  computed: {
+    ...mapState({
+      lastComms: state => state.info.lastComms,
+      currentBlock: state => state.info.currentBlock,
+      source: state => state.info.source
+    })
+  },
+
+  watch: {
+    lastComms: {
+      handler: function () {
+        console.log('Updated info')
+        this.healthCheckMins()
+      },
+      deep: true
+    }
+  },
+
+  mounted () {
+    // Calculate minutes for health check
+    this.healthCheckMins()
+
+    // Updates every minute
+    setInterval(() => {
+      this.healthCheckMins()
+    }, 60000)
+  },
+
+  methods: {
+    healthCheckMins () {
+      this.verifiedAt = this.currentBlock.verifiedAt ? getMinsAgo(this.currentBlock.verifiedAt) : null
+      this.lastCommsExternal = this.lastComms.external ? getMinsAgo(this.lastComms.external) : null
+      this.lastCommsRelay = this.lastComms.relay ? getMinsAgo(this.lastComms.relay) : null
+    }
+  }
+}
+</script>
+
+<style>
+.relay-updates {
+  margin-top: 50px;
+  padding: 20px;
+  max-width: 500px;
+}
+
+.relay-updates__title {
+  width: 200px;
+  font-weight: 900;
+}
+
+@media (max-width: 800px) {
+  .relay-updates {
+    max-width: none;
+  }
+}
+</style>

--- a/golang/dashboard/src/components/Relay-Health-Check.vue
+++ b/golang/dashboard/src/components/Relay-Health-Check.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card class="relay-updates">
+  <div class="relay-updates">
     <v-layout>
       <p class="relay-updates__title">Relay Health Check:</p>
       <p v-if="lastCommsRelay === null">Not completed</p>
@@ -26,7 +26,7 @@
       <p class="relay-updates__title">Source Height:</p>
       <p>{{ currentBlock.height || 'Unknown' }}</p>
     </v-layout>
-  </v-card>
+  </div>
 </template>
 
 <script>
@@ -35,11 +35,6 @@ import { getMinsAgo } from '@/utils/utils'
 
 export default {
   name: 'RelayHealthCheck',
-
-  components: {
-    ClickToCopy: () => import(/* webpackChunkName: 'Click-To-Copy' */ './Click-To-Copy'),
-    NetType: () => import(/* webpackChunkName: 'Net-Type' */ './Net-Type')
-  },
 
   data: () => ({
     verifiedAt: null,
@@ -87,9 +82,8 @@ export default {
 
 <style>
 .relay-updates {
-  margin-top: 50px;
-  padding: 20px;
-  max-width: 500px;
+  margin-top: 20px;
+  /* max-width: 500px; */
 }
 
 .relay-updates__title {

--- a/golang/dashboard/src/components/Relay-Info.vue
+++ b/golang/dashboard/src/components/Relay-Info.vue
@@ -28,7 +28,7 @@
           </v-layout>
 
           <v-flex class="relay__info__info" row>
-            <p>Height: {{ height }}</p>
+            <p>Height: {{ currentBlock.height }}</p>
             <Click-To-Copy :copy-value="height"/>
           </v-flex>
 
@@ -41,11 +41,12 @@
             <Click-To-Copy :copy-value="currentBlock.hash"/>
           </v-flex>
 
-          <v-flex class="relay__info__info" row>
+          <!-- <v-flex class="relay__info__info" row>
+            TODO: Fix verifiedAt
             <p v-if="verifiedAt === null">Unverified</p>
             <p v-else-if="verifiedAt < 1">Verified: Less than 1 minute ago</p>
             <p v-else>Verified: {{ verifiedAt }} minute<span v-if="verifiedAt > 1">s</span> ago</p>
-          </v-flex>
+          </v-flex> -->
         </v-layout>
 
         <v-divider/>
@@ -90,115 +91,41 @@
       </div>
     </v-card>
 
-    <v-card class="relay__updates">
-      <v-layout>
-        <p class="relay__updates__title">Relay Health Check:</p>
-        <p v-if="lastCommsRelay === null">Not completed</p>
-        <p v-else-if="lastCommsRelay < 1">Less than 1 minute ago</p>
-        <p v-else>{{ lastCommsRelay }} minute<span v-if="lastCommsRelay > 1">s</span> ago</p>
-      </v-layout>
-      <v-layout>
-        <p class="relay__updates__title">Source:</p>
-        <p>{{ source }}</p>
-      </v-layout>
-      <v-layout>
-        <p class="relay__updates__title">Source Health Check:</p>
-        <p v-if="lastCommsExternal === null">Not completed</p>
-        <p v-else-if="lastCommsExternal < 1">Less than 1 minute ago</p>
-        <p v-else>{{ lastCommsExternal }} minute<span v-if="lastCommsExternal > 1">s</span> ago</p>
-      </v-layout>
-      <v-layout>
-        <p class="relay__updates__title">Source Block Changed:</p>
-        <p v-if="verifiedAt === null">Unknown</p>
-        <p v-else-if="verifiedAt < 1">Less than 1 minute ago</p>
-        <p v-else>{{ verifiedAt }} minute<span v-if="verifiedAt > 1">s</span> ago</p>
-      </v-layout>
-      <v-layout>
-        <p class="relay__updates__title">Source Height:</p>
-        <p>{{ height || 'Unknown' }}</p>
-      </v-layout>
-    </v-card>
-
-    <!-- <v-card>
-      <v-btn @click="getBKD">Get BKD</v-btn>
-      <v-btn @click="getLCA">Get LCA</v-btn>
-      <v-btn @click="getCurrentHeight">Get Current Height</v-btn>
-    </v-card> -->
+    <Relay-Health-Check />
   </v-container>
 </template>
 
 <script>
 import { mapState } from 'vuex'
-import { getMinsAgo } from '@/utils/utils'
 
 export default {
-  name: 'relay',
+  name: 'Relay',
 
   components: {
+    RelayHealthCheck: () => import(/* webpackChunkName: 'Relay-Health-Check' */ './Relay-Health-Check'),
     ClickToCopy: () => import(/* webpackChunkName: 'Click-To-Copy' */ './Click-To-Copy'),
     NetType: () => import(/* webpackChunkName: 'Net-Type' */ './Net-Type')
   },
 
   data: () => ({
     windowWidth: Number,
-    verifiedAt: null,
-    lastCommsExternal: null,
-    lastCommsRelay: null
+    verifiedAt: null
   }),
+
+  computed: {
+    ...mapState({
+      currentBlock: state => state.info.currentBlock,
+      relay: state => state.info.relay
+    })
+  },
 
   mounted () {
     this.onResize()
-
-    // Calculate minutes for health check
-    this.healthCheckMins()
-
-    // Updates every minute
-    setInterval(() => {
-      this.healthCheckMins()
-    }, 60000)
   },
 
   methods: {
     onResize () {
       this.windowWidth = window.innerWidth
-    },
-
-    healthCheckMins () {
-      this.verifiedAt = this.currentBlock.verifiedAt ? getMinsAgo(this.currentBlock.verifiedAt) : null
-      this.lastCommsExternal = this.lastComms.external ? getMinsAgo(this.lastComms.external) : null
-      this.lastCommsRelay = this.lastComms.relay ? getMinsAgo(this.lastComms.relay) : null
-    }
-
-    // getBKD () {
-    //   this.$store.dispatch('relay/getBKD')
-    // },
-
-    // getLCA () {
-    //   this.$store.dispatch('relay/getLCA')
-    // },
-
-    // getCurrentHeight () {
-    //   this.$store.dispatch('relay/verifyHeight', this.currentBlock.hash)
-    // }
-  },
-
-  computed: {
-    ...mapState({
-      lastComms: state => state.info.lastComms,
-      currentBlock: state => state.info.currentBlock,
-      height: state => state.info.currentBlock.height,
-      relay: state => state.info.relay,
-      source: state => state.info.source
-    })
-  },
-
-  watch: {
-    lastComms: {
-      handler: function () {
-        console.log('Updated info')
-        this.healthCheckMins()
-      },
-      deep: true
     }
   },
 
@@ -240,23 +167,9 @@ export default {
   margin-left: 0px;
 }
 
-.relay__updates {
-  margin-top: 50px;
-  padding: 20px;
-  max-width: 500px;
-}
-
-.relay__updates__title {
-  width: 200px;
-  font-weight: 900;
-}
-
 @media (max-width: 800px) {
   .relay {
     padding: 0 20px;
-  }
-  .relay__updates {
-    max-width: none;
   }
 }
 </style>

--- a/golang/dashboard/src/components/Relay-Info.vue
+++ b/golang/dashboard/src/components/Relay-Info.vue
@@ -50,12 +50,11 @@
             <Click-To-Copy :copy-value="currentBlock.hash"/>
           </v-flex>
 
-          <!-- <v-flex class="relay__info__info" row>
-            TODO: Fix verifiedAt
+          <v-flex class="relay__info__info" row>
             <p v-if="verifiedAt === null">Unverified</p>
             <p v-else-if="verifiedAt < 1">Verified: Less than 1 minute ago</p>
             <p v-else>Verified: {{ verifiedAt }} minute<span v-if="verifiedAt > 1">s</span> ago</p>
-          </v-flex> -->
+          </v-flex>
         </v-layout>
 
         <v-divider/>
@@ -116,13 +115,13 @@ export default {
 
   data: () => ({
     windowWidth: Number,
-    verifiedAt: null
   }),
 
   computed: {
     ...mapState({
       currentBlock: state => state.info.currentBlock,
-      relay: state => state.info.relay
+      relay: state => state.info.relay,
+      verifiedAt: state => state.info.minsAgo.currentBlockVerified
     })
   },
 

--- a/golang/dashboard/src/components/Relay-Info.vue
+++ b/golang/dashboard/src/components/Relay-Info.vue
@@ -19,7 +19,7 @@
         <v-layout class="relay__info__line" column>
           <v-layout>
             <h3 class="relay__info__title">Current Block:</h3>
-            <v-tooltip top>
+            <v-tooltip top nudge-bottom="5">
               <template v-slot:activator="{ on }">
                 <v-icon v-on="on" size="20px">help</v-icon>
               </template>
@@ -28,23 +28,23 @@
           </v-layout>
 
           <v-flex class="relay__info__info" row>
-            <p><b>Height:</b> {{ height }}</p>
+            <p>Height: {{ height }}</p>
             <Click-To-Copy :copy-value="height"/>
           </v-flex>
 
           <v-flex class="relay__info__info" row>
             <p>
-              <b>Hash:</b>
-              <span v-if="windowWidth < 800"> {{ currentBlock.hash | crop }}</span>
+              <span>Hash: </span>
+              <span v-if="windowWidth < 800">{{ currentBlock.hash | crop }}</span>
               <span v-else>{{ currentBlock.hash }}</span>
             </p>
             <Click-To-Copy :copy-value="currentBlock.hash"/>
           </v-flex>
 
           <v-flex class="relay__info__info" row>
-            <p v-if="verifiedAt === null"><b>Verified:</b> Unverified</p>
-            <p v-else-if="verifiedAt < 1">Less than 1 minute ago</p>
-            <p v-else><b>Verified:</b> {{ verifiedAt }} minute<span v-if="verifiedAt > 1">s</span> ago</p>
+            <p v-if="verifiedAt === null">Unverified</p>
+            <p v-else-if="verifiedAt < 1">Verified: Less than 1 minute ago</p>
+            <p v-else>Verified: {{ verifiedAt }} minute<span v-if="verifiedAt > 1">s</span> ago</p>
           </v-flex>
         </v-layout>
 
@@ -53,7 +53,7 @@
         <v-layout class="relay__info__line" column>
           <v-layout>
             <h3 class="relay__info__title">Best Known Digest:</h3>
-            <v-tooltip top>
+            <v-tooltip top nudge-bottom="5">
               <template v-slot:activator="{ on }">
                 <v-icon v-on="on" size="20px">help</v-icon>
               </template>
@@ -74,7 +74,7 @@
           <v-layout>
             <h3 class="relay__info__title">Common Ancestor of Last Reorg:</h3>
 
-            <v-tooltip top>
+            <v-tooltip top nudge-bottom="5">
               <template v-slot:activator="{ on }">
                 <v-icon v-on="on" size="20px">help</v-icon>
               </template>

--- a/golang/dashboard/src/components/Relay-Info.vue
+++ b/golang/dashboard/src/components/Relay-Info.vue
@@ -4,16 +4,25 @@
     class="relay"
   >
     <v-card class="relay__card">
-      <v-toolbar color="teal" dark>
-        <v-toolbar-title>Relay Info</v-toolbar-title>
-        <v-spacer/>
-        <Net-Type></Net-Type>
-
-        <!-- <v-spacer></v-spacer>
-        <v-btn icon>
-          <v-icon>mdi-dots-vertical</v-icon>
-        </v-btn> -->
-      </v-toolbar>
+      <v-card
+        class="relay__card__banner"
+        tile
+        color="teal"
+        dark
+      >
+        <v-layout column>
+          <v-layout
+            class="relay__card__banner__title"
+            row
+            justify-space-between
+            align-content-center
+          >
+            <h2>Relay Info</h2>
+            <Net-Type/>
+          </v-layout>
+          <Relay-Health-Check />
+        </v-layout>
+      </v-card>
 
       <div class="relay__info">
         <v-layout class="relay__info__line" column>
@@ -29,7 +38,7 @@
 
           <v-flex class="relay__info__info" row>
             <p>Height: {{ currentBlock.height }}</p>
-            <Click-To-Copy :copy-value="height"/>
+            <Click-To-Copy :copy-value="currentBlock.height"/>
           </v-flex>
 
           <v-flex class="relay__info__info" row>
@@ -90,8 +99,6 @@
         </v-layout>
       </div>
     </v-card>
-
-    <Relay-Health-Check />
   </v-container>
 </template>
 
@@ -142,11 +149,17 @@ export default {
 <style scoped>
 .relay {
   max-width: 1264px;
-  padding: 0 60px;
+  padding: 60px;
 }
 
-.relay__card {
-  margin-top: 50px;
+.relay__card__banner {
+  padding: 20px;
+}
+
+.relay__card__banner__title {
+  margin: 0;
+  padding-bottom: 10px;
+  border-bottom: 1px solid white;
 }
 
 .relay__info {
@@ -169,7 +182,7 @@ export default {
 
 @media (max-width: 800px) {
   .relay {
-    padding: 0 20px;
+    padding: 40px 20px;
   }
 }
 </style>

--- a/golang/dashboard/src/store/info.js
+++ b/golang/dashboard/src/store/info.js
@@ -121,11 +121,13 @@ Digest:,
       }
       // Than verify height against relay
       dispatch('relay/verifyHeight', hash.toString(), { root: true })
+
+      // Set last communication
+      dispatch('setLastComms', { source: 'external', date: new Date() })
     }).catch((err) => {
       console.log('blockcypher error', err)
     })
 
-    dispatch('setLastComms', { source: 'external', date: new Date() })
   }
 }
 

--- a/golang/dashboard/src/store/info.js
+++ b/golang/dashboard/src/store/info.js
@@ -31,6 +31,12 @@ const state = {
   relay: lStorage.get('relay') || {
     bkd: '',     // String - best known digest
     lca: ''      // String - last (reorg) common ancestor
+  },
+
+  minsAgo: {
+    currentBlockVerified: null,
+    relayHealthCheck: null,
+    sourceHealthCheck: null
   }
 }
 
@@ -61,6 +67,10 @@ const mutations = {
   [types.SET_RELAY_INFO] (state, { key, data }) {
     state.relay[key] = data
     lStorage.set('relay', state.relay)
+  },
+
+  [types.SET_MINS_AGO] (state, payload) {
+    state.minsAgo = payload
   }
 }
 
@@ -92,9 +102,16 @@ const actions = {
     dispatch('setCurrentBlock', data)
   },
 
-  // payload: { name: '', value: '' }
+  // payload: { key: '', data: '' }
   setRelayInfo ({ commit }, payload) {
     commit(types.SET_RELAY_INFO, payload)
+  },
+
+  // Note: This can be broken up in the future if we need to update these separately,
+  //       but right now they are all getting updated at the same time.
+  // payload: { currentBlockVerified: 0, relayHealthCheck: 0, sourceHealthCheck: 0 }
+  setMinsAgo ({ commit }, payload) {
+    commit(types.SET_MINS_AGO, payload)
   },
 
   getExternalInfo ({ dispatch, state }) {

--- a/golang/dashboard/src/store/mutation-types.js
+++ b/golang/dashboard/src/store/mutation-types.js
@@ -5,6 +5,7 @@ export const SET_LAST_COMMS = 'info/SET_LAST_COMMS'
 export const SET_CURRENT_BLOCK = 'info/SET_CURRENT_BLOCK'
 export const ADD_PREVIOUS_BLOCK = 'info/ADD_PREVIOUS_BLOCK'
 export const UPDATE_NOW = 'info/UPDATE_NOW'
+export const SET_MINS_AGO = 'info/SET_MINS_AGO'
 
 // relay
 export const GET_BKD = 'relay/GET_BKD'

--- a/golang/dashboard/src/store/relay.js
+++ b/golang/dashboard/src/store/relay.js
@@ -91,15 +91,6 @@ const actions = {
       )
     }
   }
-
-  // // Called when external info updates
-  // relay_socket_return_verify_height ({ dispatch }, data) {
-  //   console.log('return verify height', data)
-  //   if (data) {
-  //     dispatch('info/setCurrentBlock', { verifiedAt: new Date() })
-  //     dispatch('info/setLastComms', { source: 'relay', date: new Date() })
-  //   }
-  // }
 }
 
 // state,


### PR DESCRIPTION
Closes #83 

 - Creates new `Relay-Health-Check` component to clean up `Relay-Info`
 - Saves `minsAgo` for health checks in store to be accessible from `Relay-Info`
 - Moves health check info into title bar