### PR TITLE
Rearrange Health Check Info

### DIFF
--- a/golang/dashboard/src/App.vue
+++ b/golang/dashboard/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app>
+  <v-app class="app">
     <v-app-bar app>
       <v-layout
         justify-space-between
@@ -67,7 +67,9 @@ export default {
     this.getExternalInfo()
     // Get external info and set it in the store, start polling
     setInterval(this.getExternalInfo, 120000)
-    setInterval(this.getRelayInfo, 60000)
+    setInterval(this.getRelayInfo, 120000)
+
+    this.onResize()
   },
 
   methods: {
@@ -94,6 +96,10 @@ export default {
 </script>
 
 <style>
+.app {
+  margin-bottom: 40px;
+}
+
 .nav__content {
   max-width: 1200px;
   margin: auto;
@@ -101,10 +107,5 @@ export default {
 .nav__title {
   font-weight: 500;
   font-size: 0.8em;
-}
-
-.relay {
-  max-width: 1264px;
-  padding: 60px;
 }
 </style>

--- a/golang/dashboard/src/App.vue
+++ b/golang/dashboard/src/App.vue
@@ -31,9 +31,7 @@
     <Relay-Connection />
 
     <v-content>
-      <v-container
-        class="relay"
-      >
+      <v-container>
         <Relay-Info />
         <ExternalInfo />
       </v-container>
@@ -66,7 +64,7 @@ export default {
     this.getExternalInfo()
     // Get external info and set it in the store, start polling
     setInterval(this.getExternalInfo, 120000)
-    setInterval(this.getRelayInfo, 120000)
+    setInterval(this.getRelayInfo, 60000)
   },
 
   methods: {

--- a/golang/dashboard/src/App.vue
+++ b/golang/dashboard/src/App.vue
@@ -31,15 +31,18 @@
     <Relay-Connection />
 
     <v-content>
-      <Relay-Info/>
+      <v-container
+        v-resize="onResize"
+        class="relay"
+      >
+        <Relay-Info />
+        <ExternalInfo />
+      </v-container>
     </v-content>
   </v-app>
 </template>
 
 <script>
-import RelayInfo from './components/Relay-Info'
-import RelayConnection from './components/Relay-Connection'
-
 export default {
   name: 'OperatedRelayDashboard',
 
@@ -53,8 +56,9 @@ export default {
   },
 
   components: {
-    RelayInfo,
-    RelayConnection
+    RelayInfo: () => import(/* webpackChunkName: 'Relay-Info' */ './components/Relay-Info'),
+    RelayConnection: () => import(/* webpackChunkName: 'Relay-Connection' */ './components/Relay-Connection'),
+    ExternalInfo: () => import(/* webpackChunkName: 'External-Info' */ './components/External-Info')
   },
 
   mounted () {
@@ -80,6 +84,10 @@ export default {
     updateAll () {
       this.getRelayInfo()
       this.getExternalInfo()
+    },
+
+    onResize () {
+      this.windowWidth = window.innerWidth
     }
   }
 }
@@ -93,5 +101,10 @@ export default {
 .nav__title {
   font-weight: 500;
   font-size: 0.8em;
+}
+
+.relay {
+  max-width: 1264px;
+  padding: 60px;
 }
 </style>

--- a/golang/dashboard/src/App.vue
+++ b/golang/dashboard/src/App.vue
@@ -32,7 +32,6 @@
 
     <v-content>
       <v-container
-        v-resize="onResize"
         class="relay"
       >
         <Relay-Info />
@@ -68,8 +67,6 @@ export default {
     // Get external info and set it in the store, start polling
     setInterval(this.getExternalInfo, 120000)
     setInterval(this.getRelayInfo, 120000)
-
-    this.onResize()
   },
 
   methods: {
@@ -86,10 +83,6 @@ export default {
     updateAll () {
       this.getRelayInfo()
       this.getExternalInfo()
-    },
-
-    onResize () {
-      this.windowWidth = window.innerWidth
     }
   }
 }

--- a/golang/dashboard/src/components/Display-Mins.vue
+++ b/golang/dashboard/src/components/Display-Mins.vue
@@ -9,13 +9,33 @@
 </template>
 
 <script>
+import { getMinsAgo } from '@/utils/utils'
+
 export default {
   name: 'DisplayMins',
 
   props: {
-    minsAgo: {
+    timestamp: {
       required: true,
-      type: Number
+      type: Date,
+      default: null
+    }
+  },
+
+  data: () => ({
+    minsAgo: null
+  }),
+
+  mounted () {
+    this.updateMinsAgo()
+    setInterval(() => {
+      this.updateMinsAgo()
+    }, 10000)
+  },
+
+  methods: {
+    updateMinsAgo () {
+      this.minsAgo = this.timestamp ? getMinsAgo(this.timestamp) : null
     }
   }
 }

--- a/golang/dashboard/src/components/Display-Mins.vue
+++ b/golang/dashboard/src/components/Display-Mins.vue
@@ -3,7 +3,7 @@
     <v-layout>
       <p v-if="minsAgo === null">Not completed</p>
       <p v-else-if="minsAgo < 1">Less than 1 minute ago</p>
-      <p v-else>{{ minsAgo }} minute<span v-if="lastCommsExternal > 1">s</span> ago</p>
+      <p v-else>{{ minsAgo }} minute<span v-if="minsAgo > 1">s</span> ago</p>
     </v-layout>
   </div>
 </template>

--- a/golang/dashboard/src/components/Display-Mins.vue
+++ b/golang/dashboard/src/components/Display-Mins.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="display-mins">
+    <v-layout>
+      <p v-if="minsAgo === null">Not completed</p>
+      <p v-else-if="minsAgo < 1">Less than 1 minute ago</p>
+      <p v-else>{{ minsAgo }} minute<span v-if="lastCommsExternal > 1">s</span> ago</p>
+    </v-layout>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'DisplayMins',
+
+  props: {
+    minsAgo: {
+      required: true,
+      type: Number
+    }
+  }
+}
+</script>

--- a/golang/dashboard/src/components/External-Info.vue
+++ b/golang/dashboard/src/components/External-Info.vue
@@ -1,24 +1,25 @@
 <template>
-  <v-card class="relay-updates">
+  <v-card class="external-info">
     <h3>External Info</h3>
+    <v-divider class="external-info__divider" />
     <v-layout>
-      <p class="relay-updates__title">Source:</p>
+      <p class="external-info__item">Source:</p>
       <p>{{ source }}</p>
     </v-layout>
     <v-layout>
-      <p class="relay-updates__title">Source Health Check:</p>
+      <p class="external-info__item">Health Check:</p>
       <p v-if="lastCommsExternal === null">Not completed</p>
       <p v-else-if="lastCommsExternal < 1">Less than 1 minute ago</p>
       <p v-else>{{ lastCommsExternal }} minute<span v-if="lastCommsExternal > 1">s</span> ago</p>
     </v-layout>
     <v-layout>
-      <p class="relay-updates__title">Source Block Changed:</p>
+      <p class="external-info__item">Block Changed:</p>
       <p v-if="verifiedAt === null">Unknown</p>
       <p v-else-if="verifiedAt < 1">Less than 1 minute ago</p>
       <p v-else>{{ verifiedAt }} minute<span v-if="verifiedAt > 1">s</span> ago</p>
     </v-layout>
     <v-layout>
-      <p class="relay-updates__title">Source Height:</p>
+      <p class="external-info__item">Height:</p>
       <p>{{ currentBlock.height || 'Unknown' }}</p>
     </v-layout>
   </v-card>
@@ -78,19 +79,23 @@ export default {
 </script>
 
 <style>
-.relay-updates {
+.external-info {
   margin-top: 40px;
   padding: 20px;
   max-width: 500px;
 }
 
-.relay-updates__title {
+.external-info__divider {
+  margin: 10px 0 20px 0;
+}
+
+.external-info__item {
   width: 200px;
   font-weight: 900;
 }
 
 @media (max-width: 800px) {
-  .relay-updates {
+  .external-info {
     max-width: none;
   }
 }

--- a/golang/dashboard/src/components/External-Info.vue
+++ b/golang/dashboard/src/components/External-Info.vue
@@ -1,11 +1,6 @@
 <template>
-  <div class="relay-updates">
-    <v-layout>
-      <p class="relay-updates__title">Relay Health Check:</p>
-      <p v-if="lastCommsRelay === null">Not completed</p>
-      <p v-else-if="lastCommsRelay < 1">Less than 1 minute ago</p>
-      <p v-else>{{ lastCommsRelay }} minute<span v-if="lastCommsRelay > 1">s</span> ago</p>
-    </v-layout>
+  <v-card class="relay-updates">
+    <h3>External Info</h3>
     <v-layout>
       <p class="relay-updates__title">Source:</p>
       <p>{{ source }}</p>
@@ -26,7 +21,7 @@
       <p class="relay-updates__title">Source Height:</p>
       <p>{{ currentBlock.height || 'Unknown' }}</p>
     </v-layout>
-  </div>
+  </v-card>
 </template>
 
 <script>
@@ -34,7 +29,7 @@ import { mapState } from 'vuex'
 import { getMinsAgo } from '@/utils/utils'
 
 export default {
-  name: 'RelayHealthCheck',
+  name: 'ExternalInfo',
 
   computed: {
     ...mapState({
@@ -42,8 +37,7 @@ export default {
       currentBlock: state => state.info.currentBlock,
       source: state => state.info.source,
       verifiedAt: state => state.info.minsAgo.currentBlockVerified,
-      lastCommsExternal: state => state.info.minsAgo.sourceHealthCheck,
-      lastCommsRelay: state => state.info.minsAgo.relayHealthCheck
+      lastCommsExternal: state => state.info.minsAgo.sourceHealthCheck
     })
   },
 
@@ -85,8 +79,9 @@ export default {
 
 <style>
 .relay-updates {
-  margin-top: 20px;
-  /* max-width: 500px; */
+  margin-top: 40px;
+  padding: 20px;
+  max-width: 500px;
 }
 
 .relay-updates__title {

--- a/golang/dashboard/src/components/External-Info.vue
+++ b/golang/dashboard/src/components/External-Info.vue
@@ -3,23 +3,19 @@
     <h3>External Info</h3>
     <v-divider class="external-info__divider" />
     <v-layout>
-      <p class="external-info__item">Source:</p>
+      <p class="external-info__item mr-2">Source:</p>
       <p>{{ source }}</p>
     </v-layout>
     <v-layout>
-      <p class="external-info__item">Health Check:</p>
-      <p v-if="lastCommsExternal === null">Not completed</p>
-      <p v-else-if="lastCommsExternal < 1">Less than 1 minute ago</p>
-      <p v-else>{{ lastCommsExternal }} minute<span v-if="lastCommsExternal > 1">s</span> ago</p>
+      <p class="external-info__item mr-2">Health Check:</p>
+      <Display-Mins :timestamp="lastComms.external" />
     </v-layout>
     <v-layout>
-      <p class="external-info__item">Block Changed:</p>
-      <p v-if="verifiedAt === null">Unknown</p>
-      <p v-else-if="verifiedAt < 1">Less than 1 minute ago</p>
-      <p v-else>{{ verifiedAt }} minute<span v-if="verifiedAt > 1">s</span> ago</p>
+      <p class="external-info__item mr-2">Block Changed:</p>
+      <Display-Mins :timestamp="currentBlock.verifiedAt" />
     </v-layout>
     <v-layout>
-      <p class="external-info__item">Height:</p>
+      <p class="external-info__item mr-2">Height:</p>
       <p>{{ currentBlock.height || 'Unknown' }}</p>
     </v-layout>
   </v-card>
@@ -27,53 +23,20 @@
 
 <script>
 import { mapState } from 'vuex'
-import { getMinsAgo } from '@/utils/utils'
 
 export default {
   name: 'ExternalInfo',
+
+  components: {
+    DisplayMins: () => import(/* webpackChunkName: 'Display-Mins' */ './Display-Mins')
+  },
 
   computed: {
     ...mapState({
       lastComms: state => state.info.lastComms,
       currentBlock: state => state.info.currentBlock,
-      source: state => state.info.source,
-      verifiedAt: state => state.info.minsAgo.currentBlockVerified,
-      lastCommsExternal: state => state.info.minsAgo.sourceHealthCheck
+      source: state => state.info.source
     })
-  },
-
-  watch: {
-    lastComms: {
-      handler: function () {
-        console.log('Updated info')
-        this.healthCheckMins()
-      },
-      deep: true
-    }
-  },
-
-  mounted () {
-    // Calculate minutes for health check
-    this.healthCheckMins()
-
-    // Updates every minute
-    setInterval(() => {
-      this.healthCheckMins()
-    }, 60000)
-  },
-
-  methods: {
-    healthCheckMins () {
-      const currentBlockVerified = this.currentBlock.verifiedAt ? getMinsAgo(this.currentBlock.verifiedAt) : null
-      const relayHealthCheck = this.lastComms.relay ? getMinsAgo(this.lastComms.relay) : null
-      const sourceHealthCheck = this.lastComms.external ? getMinsAgo(this.lastComms.external) : null
-
-      this.$store.dispatch('info/setMinsAgo', {
-        currentBlockVerified,
-        relayHealthCheck,
-        sourceHealthCheck
-      })
-    }
   }
 }
 </script>

--- a/golang/dashboard/src/components/Relay-Info.vue
+++ b/golang/dashboard/src/components/Relay-Info.vue
@@ -1,104 +1,104 @@
 <template>
-  <v-container
-    v-resize="onResize"
-    class="relay"
-  >
-    <v-card class="relay__card">
-      <v-card
-        class="relay__card__banner"
-        tile
-        color="teal"
-        dark
-      >
-        <v-layout column>
-          <v-layout
-            class="relay__card__banner__title"
-            row
-            justify-space-between
-            align-content-center
-          >
+  <v-card class="relay-info">
+    <v-card
+      class="relay-info__banner"
+      tile
+      color="teal"
+      dark
+    >
+      <v-layout column>
+        <v-layout
+          class="relay-info__banner__title"
+          row
+          justify-space-between
+          align-content-center
+        >
+          <v-layout column>
             <h2>Relay Info</h2>
-            <Net-Type/>
+            <v-layout>
+              <p>Health Check: </p>
+              <Display-Mins :mins-ago="lastCommsRelay" />
+            </v-layout>
           </v-layout>
-          <Relay-Health-Check />
+          <Net-Type/>
         </v-layout>
-      </v-card>
-
-      <div class="relay__info">
-        <v-layout class="relay__info__line" column>
-          <v-layout>
-            <h3 class="relay__info__title">Current Block:</h3>
-            <v-tooltip top nudge-bottom="5">
-              <template v-slot:activator="{ on }">
-                <v-icon v-on="on" size="20px">help</v-icon>
-              </template>
-              <span>The most recent valid block detected by the relay</span>
-            </v-tooltip>
-          </v-layout>
-
-          <v-flex class="relay__info__info" row>
-            <p>Height: {{ currentBlock.height }}</p>
-            <Click-To-Copy :copy-value="currentBlock.height"/>
-          </v-flex>
-
-          <v-flex class="relay__info__info" row>
-            <p>
-              <span>Hash: </span>
-              <span v-if="windowWidth < 800">{{ currentBlock.hash | crop }}</span>
-              <span v-else>{{ currentBlock.hash }}</span>
-            </p>
-            <Click-To-Copy :copy-value="currentBlock.hash"/>
-          </v-flex>
-
-          <v-flex class="relay__info__info" row>
-            <p v-if="verifiedAt === null">Unverified</p>
-            <p v-else-if="verifiedAt < 1">Verified: Less than 1 minute ago</p>
-            <p v-else>Verified: {{ verifiedAt }} minute<span v-if="verifiedAt > 1">s</span> ago</p>
-          </v-flex>
-        </v-layout>
-
-        <v-divider/>
-
-        <v-layout class="relay__info__line" column>
-          <v-layout>
-            <h3 class="relay__info__title">Best Known Digest:</h3>
-            <v-tooltip top nudge-bottom="5">
-              <template v-slot:activator="{ on }">
-                <v-icon v-on="on" size="20px">help</v-icon>
-              </template>
-              <span>The digest of the best block, updated approximately every 5 blocks</span>
-            </v-tooltip>
-          </v-layout>
-
-          <v-flex class="relay__info__info" row>
-            <p v-if="windowWidth < 800">{{ relay.bkd | crop }}</p>
-            <p v-else>{{ relay.bkd }}</p>
-            <Click-To-Copy :copy-value="relay.bkd"/>
-          </v-flex>
-        </v-layout>
-
-        <v-divider/>
-
-        <v-layout class="relay__info__line" column>
-          <v-layout>
-            <h3 class="relay__info__title">Common Ancestor of Last Reorg:</h3>
-
-            <v-tooltip top nudge-bottom="5">
-              <template v-slot:activator="{ on }">
-                <v-icon v-on="on" size="20px">help</v-icon>
-              </template>
-              <span>The latest ancestral block of both the current best known digest and the previous best known digest</span>
-            </v-tooltip>
-          </v-layout>
-          <v-flex class="relay__info__info" row>
-            <p v-if="windowWidth < 800">{{ relay.lca | crop }}</p>
-            <p v-else>{{ relay.lca }}</p>
-            <Click-To-Copy :copy-value="relay.lca"/>
-          </v-flex>
-        </v-layout>
-      </div>
+      </v-layout>
     </v-card>
-  </v-container>
+
+    <div class="relay-info__info">
+      <v-layout class="relay-info__info__line" column>
+        <v-layout>
+          <h3 class="relay-info__info__title">Current Block:</h3>
+          <v-tooltip top nudge-bottom="5">
+            <template v-slot:activator="{ on }">
+              <v-icon v-on="on" size="20px">help</v-icon>
+            </template>
+            <span>The most recent valid block detected by the relay</span>
+          </v-tooltip>
+        </v-layout>
+
+        <v-flex class="relay-info__info__data" row>
+          <p>Height: {{ currentBlock.height }}</p>
+          <Click-To-Copy :copy-value="currentBlock.height"/>
+        </v-flex>
+
+        <v-flex class="relay-info__info__data" row>
+          <p>
+            <span>Hash: </span>
+            <span v-if="windowWidth < 800">{{ currentBlock.hash | crop }}</span>
+            <span v-else>{{ currentBlock.hash }}</span>
+          </p>
+          <Click-To-Copy :copy-value="currentBlock.hash"/>
+        </v-flex>
+
+        <v-flex class="relay-info__info__data" row>
+          <p v-if="verifiedAt === null">Unverified</p>
+          <p v-else-if="verifiedAt < 1">Verified: Less than 1 minute ago</p>
+          <p v-else>Verified: {{ verifiedAt }} minute<span v-if="verifiedAt > 1">s</span> ago</p>
+        </v-flex>
+      </v-layout>
+
+      <v-divider/>
+
+      <v-layout class="relay-info__info__line" column>
+        <v-layout>
+          <h3 class="relay-info__info__title">Best Known Digest:</h3>
+          <v-tooltip top nudge-bottom="5">
+            <template v-slot:activator="{ on }">
+              <v-icon v-on="on" size="20px">help</v-icon>
+            </template>
+            <span>The digest of the best block, updated approximately every 5 blocks</span>
+          </v-tooltip>
+        </v-layout>
+
+        <v-flex class="relay-info__info__data" row>
+          <p v-if="windowWidth < 800">{{ relay.bkd | crop }}</p>
+          <p v-else>{{ relay.bkd }}</p>
+          <Click-To-Copy :copy-value="relay.bkd"/>
+        </v-flex>
+      </v-layout>
+
+      <v-divider/>
+
+      <v-layout class="relay-info__info__line" column>
+        <v-layout>
+          <h3 class="relay-info__info__title">Common Ancestor of Last Reorg:</h3>
+
+          <v-tooltip top nudge-bottom="5">
+            <template v-slot:activator="{ on }">
+              <v-icon v-on="on" size="20px">help</v-icon>
+            </template>
+            <span>The latest ancestral block of both the current best known digest and the previous best known digest</span>
+          </v-tooltip>
+        </v-layout>
+        <v-flex class="relay-info__info__data" row>
+          <p v-if="windowWidth < 800">{{ relay.lca | crop }}</p>
+          <p v-else>{{ relay.lca }}</p>
+          <Click-To-Copy :copy-value="relay.lca"/>
+        </v-flex>
+      </v-layout>
+    </div>
+  </v-card>
 </template>
 
 <script>
@@ -108,8 +108,8 @@ export default {
   name: 'Relay',
 
   components: {
-    RelayHealthCheck: () => import(/* webpackChunkName: 'Relay-Health-Check' */ './Relay-Health-Check'),
     ClickToCopy: () => import(/* webpackChunkName: 'Click-To-Copy' */ './Click-To-Copy'),
+    DisplayMins: () => import(/* webpackChunkName: 'Display-Mins' */ './Display-Mins'),
     NetType: () => import(/* webpackChunkName: 'Net-Type' */ './Net-Type')
   },
 
@@ -121,18 +121,13 @@ export default {
     ...mapState({
       currentBlock: state => state.info.currentBlock,
       relay: state => state.info.relay,
-      verifiedAt: state => state.info.minsAgo.currentBlockVerified
+      verifiedAt: state => state.info.minsAgo.currentBlockVerified,
+      lastCommsRelay: state => state.info.minsAgo.relayHealthCheck
     })
   },
 
   mounted () {
     this.onResize()
-  },
-
-  methods: {
-    onResize () {
-      this.windowWidth = window.innerWidth
-    }
   },
 
   filters: {
@@ -146,42 +141,39 @@ export default {
 </script>
 
 <style scoped>
-.relay {
-  max-width: 1264px;
-  padding: 60px;
+.relay-info {
+  margin-top: 20px;
 }
 
-.relay__card__banner {
+.relay-info__banner {
   padding: 20px;
 }
 
-.relay__card__banner__title {
+.relay-info__banner__title {
   margin: 0;
-  padding-bottom: 10px;
-  border-bottom: 1px solid white;
 }
 
-.relay__info {
+.relay-info__info {
   padding: 20px;
 }
 
-.relay__info__title {
+.relay-info__info__title {
   margin-right: 7px;
   font-weight: 900;
 }
 
-.relay__info__line {
+.relay-info__info__line {
   margin-top: 30px;
 }
 
-.relay__info__info {
+.relay-info__info__data {
   font-weight: 400;
   margin-left: 0px;
 }
 
-@media (max-width: 800px) {
+/* @media (max-width: 800px) {
   .relay {
     padding: 40px 20px;
   }
-}
+} */
 </style>

--- a/golang/dashboard/src/components/Relay-Info.vue
+++ b/golang/dashboard/src/components/Relay-Info.vue
@@ -116,10 +116,6 @@ export default {
     windowWidth: Number,
   }),
 
-  mounted () {
-    this.onResize()
-  },
-
   computed: {
     ...mapState({
       lastComms: state => state.info.lastComms,
@@ -129,17 +125,21 @@ export default {
     })
   },
 
-  filters: {
-    crop (str) {
-      var first = str.slice(0, 6)
-      var last = str.slice((str.length - 6), str.length)
-      return `${first} . . . ${last}`
-    }
+  mounted () {
+    this.onResize()
   },
 
   methods: {
     onResize () {
       this.windowWidth = window.innerWidth
+    }
+  },
+
+  filters: {
+    crop (str) {
+      var first = str.slice(0, 6)
+      var last = str.slice((str.length - 6), str.length)
+      return `${first} . . . ${last}`
     }
   }
 }

--- a/golang/dashboard/src/components/Relay-Info.vue
+++ b/golang/dashboard/src/components/Relay-Info.vue
@@ -16,8 +16,8 @@
           <v-layout column>
             <h2>Relay Info</h2>
             <v-layout>
-              <p>Health Check: </p>
-              <Display-Mins :mins-ago="lastCommsRelay" />
+              <p class="mr-2">Health Check:</p>
+              <Display-Mins :timestamp="lastComms.relay" />
             </v-layout>
           </v-layout>
           <Net-Type/>
@@ -52,9 +52,8 @@
         </v-flex>
 
         <v-flex class="relay-info__info__data" row>
-          <p v-if="verifiedAt === null">Unverified</p>
-          <p v-else-if="verifiedAt < 1">Verified: Less than 1 minute ago</p>
-          <p v-else>Verified: {{ verifiedAt }} minute<span v-if="verifiedAt > 1">s</span> ago</p>
+          <p class="mr-2">Verified:</p>
+          <Display-Mins :timestamp="currentBlock.verifiedAt" />
         </v-flex>
       </v-layout>
 
@@ -119,15 +118,11 @@ export default {
 
   computed: {
     ...mapState({
+      lastComms: state => state.info.lastComms,
       currentBlock: state => state.info.currentBlock,
       relay: state => state.info.relay,
-      verifiedAt: state => state.info.minsAgo.currentBlockVerified,
-      lastCommsRelay: state => state.info.minsAgo.relayHealthCheck
+      verifiedAt: state => state.info.minsAgo.currentBlockVerified
     })
-  },
-
-  mounted () {
-    this.onResize()
   },
 
   filters: {
@@ -170,10 +165,4 @@ export default {
   font-weight: 400;
   margin-left: 0px;
 }
-
-/* @media (max-width: 800px) {
-  .relay {
-    padding: 40px 20px;
-  }
-} */
 </style>

--- a/golang/dashboard/src/components/Relay-Info.vue
+++ b/golang/dashboard/src/components/Relay-Info.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card class="relay-info">
+  <v-card v-resize="onResize" class="relay-info">
     <v-card
       class="relay-info__banner"
       tile
@@ -116,6 +116,10 @@ export default {
     windowWidth: Number,
   }),
 
+  mounted () {
+    this.onResize()
+  },
+
   computed: {
     ...mapState({
       lastComms: state => state.info.lastComms,
@@ -130,6 +134,12 @@ export default {
       var first = str.slice(0, 6)
       var last = str.slice((str.length - 6), str.length)
       return `${first} . . . ${last}`
+    }
+  },
+
+  methods: {
+    onResize () {
+      this.windowWidth = window.innerWidth
     }
   }
 }

--- a/golang/dashboard/src/store/info.js
+++ b/golang/dashboard/src/store/info.js
@@ -31,12 +31,6 @@ const state = {
   relay: lStorage.get('relay') || {
     bkd: '',     // String - best known digest
     lca: ''      // String - last (reorg) common ancestor
-  },
-
-  minsAgo: {
-    currentBlockVerified: null,
-    relayHealthCheck: null,
-    sourceHealthCheck: null
   }
 }
 
@@ -67,10 +61,6 @@ const mutations = {
   [types.SET_RELAY_INFO] (state, { key, data }) {
     state.relay[key] = data
     lStorage.set('relay', state.relay)
-  },
-
-  [types.SET_MINS_AGO] (state, payload) {
-    state.minsAgo = payload
   }
 }
 
@@ -105,13 +95,6 @@ const actions = {
   // payload: { key: '', data: '' }
   setRelayInfo ({ commit }, payload) {
     commit(types.SET_RELAY_INFO, payload)
-  },
-
-  // Note: This can be broken up in the future if we need to update these separately,
-  //       but right now they are all getting updated at the same time.
-  // payload: { currentBlockVerified: 0, relayHealthCheck: 0, sourceHealthCheck: 0 }
-  setMinsAgo ({ commit }, payload) {
-    commit(types.SET_MINS_AGO, payload)
   },
 
   getExternalInfo ({ dispatch, state }) {


### PR DESCRIPTION
 - Separates `Relay-Info` and `External-Info` into separate components
 - Relay Info is now located in the "Relay Info" header section, and External Info is in another card at the bottom of the page
 - Creates the `Display-Mins` component which calculates and formats minutes ago nicely.  I got tired of having the same messy logic written everywhere.  This also eliminates the need to watch values and store `minsAgo` in state, very nice (: