### PR TITLE
x/relay/types/errors.go: Sprint -> Sprintf

### DIFF
--- a/golang/x/relay/types/errors.go
+++ b/golang/x/relay/types/errors.go
@@ -189,7 +189,7 @@ const (
 
 // ErrBadHeaderLength throws an error
 func ErrBadHeaderLength(codespace sdk.CodespaceType, label string, digest RawHeader, length int) sdk.Error {
-	return sdk.NewError(codespace, BadHeaderLength, fmt.Sprint(BadHeaderLengthMessage, label, digest, length))
+	return sdk.NewError(codespace, BadHeaderLength, fmt.Sprintf(BadHeaderLengthMessage, label, digest, length))
 }
 
 // ErrBadHeight throws an error
@@ -204,12 +204,12 @@ func ErrHeightMismatch(codespace sdk.CodespaceType, prevDigest, digest Hash256Di
 
 // ErrUnknownBlock throws an error
 func ErrUnknownBlock(codespace sdk.CodespaceType, label string, digest Hash256Digest) sdk.Error {
-	return sdk.NewError(codespace, UnknownBlock, fmt.Sprint(UnknownBlockMessage, label, digest))
+	return sdk.NewError(codespace, UnknownBlock, fmt.Sprintf(UnknownBlockMessage, label, digest))
 }
 
 // ErrUnexpectedRetarget throws an error
 func ErrUnexpectedRetarget(codespace sdk.CodespaceType, rawHeader RawHeader) sdk.Error {
-	return sdk.NewError(codespace, UnexpectedRetarget, fmt.Sprint(UnexpectedRetargetMessage, rawHeader))
+	return sdk.NewError(codespace, UnexpectedRetarget, fmt.Sprintf(UnexpectedRetargetMessage, rawHeader))
 }
 
 // ErrWrongEnd throws an error


### PR DESCRIPTION
Was getting errors like 

```
      "log": "{\"codespace\":\"relay\",\"code\":104,\"message\":\"Unknown block labeled %!s(MISSING) with digest %!x(MISSING)newBest[244 68 3 14 93 48 150 143 51 3 119 100 109 198 87 129 122 53 101 126 109 41 7 0 0 0 0 0 0 0 0 0]\"}",
```

When submitting junk headers